### PR TITLE
chore: migrate goreleaser brews to homebrew_casks

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -86,17 +86,16 @@ release:
 
     **Full Changelog**: https://github.com/sjoeboo/hangar/compare/{{ .PreviousTag }}...{{ .Tag }}
 
-brews:
+homebrew_casks:
   - name: hangar
     repository:
       owner: sjoeboo
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    directory: Formula
+    directory: Casks
     homepage: "https://github.com/sjoeboo/hangar"
     description: "Terminal session manager for AI coding agents"
-    license: "MIT"
     dependencies:
-      - name: tmux
-    test: |
-      system "#{bin}/hangar", "version"
+      - formula: tmux
+    zap:
+      - trash: "~/.hangar"


### PR DESCRIPTION
## What

Replaces the deprecated `brews:` key with `homebrew_casks:` in `.goreleaser.yml`.

## Why

GoReleaser v2 has deprecated `brews` in favor of `homebrew_casks`. The release workflow was emitting a deprecation warning. This fixes the warning and aligns with the new schema:

- `brews:` → `homebrew_casks:`
- `directory: Formula` → `directory: Casks`
- `dependencies: [{name: tmux}]` → `dependencies: [{formula: tmux}]`
- Added `zap` block to clean up `~/.hangar` on cask uninstall
- Removed `license:` (not part of cask schema) and `test:` block (casks don't support brew test)

## Testing

CI will validate the build. The next tagged release will confirm the Homebrew cask is generated without warnings.