### PR TITLE
fix(ui): remove double-entry bug in PR review dialog input handling

### DIFF
--- a/internal/ui/review_dialog.go
+++ b/internal/ui/review_dialog.go
@@ -177,9 +177,6 @@ func (d *ReviewDialog) HandleKey(key string) string {
 
 	default:
 		if d.step == 0 {
-			var cmd tea.Cmd
-			d.input, cmd = d.input.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)})
-			_ = cmd
 			d.errorMsg = ""
 		}
 	}

--- a/internal/ui/review_dialog_test.go
+++ b/internal/ui/review_dialog_test.go
@@ -2,6 +2,8 @@ package ui
 
 import (
 	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestReviewDialog_InitiallyHidden(t *testing.T) {
@@ -50,7 +52,7 @@ func TestReviewDialog_InputDetectsPRNumber(t *testing.T) {
 	d.Show("hangar", "/home/user/code/hangar")
 	d.SetSize(120, 40)
 	for _, r := range "42" {
-		d.HandleKey(string(r))
+		d.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
 	}
 	if !d.IsPRInput() {
 		t.Fatal("expected '42' to be detected as a PR number")
@@ -62,7 +64,7 @@ func TestReviewDialog_InputDetectsBranchName(t *testing.T) {
 	d.Show("hangar", "/home/user/code/hangar")
 	d.SetSize(120, 40)
 	for _, r := range "feature/my-branch" {
-		d.HandleKey(string(r))
+		d.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
 	}
 	if d.IsPRInput() {
 		t.Fatal("expected 'feature/my-branch' to be detected as a branch, not a PR number")


### PR DESCRIPTION
## What

Remove a double-entry bug in the PR review dialog (`v` key in the TUI) where every keystroke was processed twice, causing typed characters to appear duplicated (e.g., typing "23" would show "2233").

## Why

The `HandleKey` method was manually calling `d.input.Update` with a constructed `KeyRunes` message in its default branch, while the `Update` method was _also_ calling `d.input.Update` with the original `tea.KeyMsg`. This violated the Bubble Tea pattern: `Update` is the sole owner of state mutations from messages. The fix removes the redundant manual call from `HandleKey`'s default branch so `Update` exclusively handles character insertion.

## Testing

- Updated two existing tests to drive input through `Update` (the correct path) instead of `HandleKey`
- [x] `go test ./internal/ui/...` passes
- [x] `go test ./...` passes
- [x] Manual verification: typing in the review dialog no longer duplicates characters

## Screenshots / demo

No visual change — the fix corrects invisible duplicate state mutations that surfaced as doubled characters in the input field.