### PR TITLE
feat(ui): add terminal-adaptive theme with ANSI color support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to Hangar will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.0] - 2026-03-16
+
+### Added
+
+- **Terminal-adaptive theme** — new `theme = "terminal"` option that uses ANSI palette colors
+  (0-15) instead of hardcoded hex values. When enabled, Hangar's TUI and tmux status bar
+  automatically follow your terminal's color scheme — change your terminal to Tokyo Night,
+  Catppuccin, Gruvbox, Rosé Pine, or any other theme and Hangar adapts instantly. This is now
+  the **default theme** for new installations.
+
+- **Named theme system** — themes are now identified by canonical names (`oasis-lagoon-dark`,
+  `oasis-lagoon-light`, `terminal`) instead of just `dark`/`light`. Old values are aliased for
+  backward compatibility.
+
+- **Theme-aware tmux status bar** — `ConfigureStatusBar()` and the notification pill now use
+  ANSI color names (`colour12`, `colour10`, `default`) in terminal mode, so the powerline
+  status bar blends with your terminal theme instead of always showing Oasis Lagoon colors.
+
+- **`ColorInvertFg`** — new semantic color for inverted/highlighted elements (dark text on
+  colored backgrounds). Separated from `ColorBg` so the terminal theme can use `NoColor{}`
+  (transparent) for backgrounds while still rendering readable inverted text.
+
+### Changed
+
+- **Default theme is now `terminal`** — previously defaulted to `dark` (Oasis Lagoon Dark).
+  Existing users with `theme = "dark"` or `theme = "light"` in their config are unaffected —
+  those values are aliased to `oasis-lagoon-dark` and `oasis-lagoon-light` respectively.
+
+- **`colorPalette` uses `lipgloss.TerminalColor` interface** — palette fields changed from
+  `lipgloss.Color` (hex string) to `lipgloss.TerminalColor` (interface), enabling palettes to
+  mix hex colors, ANSI palette slots (`lipgloss.ANSIColor`), and transparent (`lipgloss.NoColor`).
+
+- **Settings panel theme options** — expanded from `Dark / Light / System` to
+  `Oasis Dark / Oasis Light / Terminal / System`.
+
 ## [2.10.0] - 2026-03-13
 
 ### Added

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -247,6 +247,7 @@ func NewInstance(title, projectPath string) *Instance {
 	tmuxSess := tmux.NewSession(title, projectPath)
 	tmuxSess.InstanceID = id // Pass instance ID for activity hooks
 	tmuxSess.SetInjectStatusLine(GetTmuxSettings().GetInjectStatusLine())
+	tmuxSess.SetTheme(ResolveTheme())
 
 	return &Instance{
 		ID:          id,
@@ -273,6 +274,7 @@ func NewInstanceWithTool(title, projectPath, tool string) *Instance {
 	tmuxSess := tmux.NewSession(title, projectPath)
 	tmuxSess.InstanceID = id // Pass instance ID for activity hooks
 	tmuxSess.SetInjectStatusLine(GetTmuxSettings().GetInjectStatusLine())
+	tmuxSess.SetTheme(ResolveTheme())
 
 	inst := &Instance{
 		ID:          id,
@@ -3288,6 +3290,7 @@ func (i *Instance) Restart() error {
 	i.tmuxSession = tmux.NewSession(i.Title, i.ProjectPath)
 	i.tmuxSession.InstanceID = i.ID // Pass instance ID for activity hooks
 	i.tmuxSession.SetInjectStatusLine(GetTmuxSettings().GetInjectStatusLine())
+	i.tmuxSession.SetTheme(ResolveTheme())
 
 	var command string
 	if i.Tool == "claude" && i.ClaudeSessionID != "" {

--- a/internal/session/notifications.go
+++ b/internal/session/notifications.go
@@ -189,31 +189,53 @@ func (nm *NotificationManager) FormatBar() string {
 	return "⚡ " + strings.Join(parts, " ")
 }
 
-// oasis_lagoon_dark status bar palette (mirrors constants in internal/tmux/tmux.go).
-// Duplicated here to avoid a cross-package import cycle.
-const (
-	notifBg     = "#22385c" // oasisSurface — notification pill background
-	notifAccent = "#58b8fd" // oasisPrimary — ⚡ prefix and default icon color
-	notifMantle = "#1a283f" // oasisMantle — transition color
-	notifGreen  = "#53d390" // running
-	notifYellow = "#f0e68c" // waiting
-	notifDim    = "#8fb0d0" // idle
-	notifRed    = "#ff7979" // error
-)
+// notifPalette holds tmux-compatible color strings for the notification pill.
+type notifPalette struct {
+	Bg, Accent, Mantle       string
+	Green, Yellow, Dim, Red string
+}
 
-// statusColor returns the tmux fg color escape for a given status, using the oasis_lagoon_dark palette.
+var oasisNotifColors = notifPalette{
+	Bg:     "#22385c", // oasisSurface
+	Accent: "#58b8fd", // oasisPrimary
+	Mantle: "#1a283f", // oasisMantle
+	Green:  "#53d390",
+	Yellow: "#f0e68c",
+	Dim:    "#8fb0d0",
+	Red:    "#ff7979",
+}
+
+var terminalNotifColors = notifPalette{
+	Bg:     "colour0",   // ANSI black — close to terminal bg, subtle pill
+	Accent: "colour12",  // bright blue
+	Mantle: "default",   // terminal default bg
+	Green:  "colour10",  // bright green
+	Yellow: "colour11",  // bright yellow
+	Dim:    "colour7",   // white (dim)
+	Red:    "colour9",   // bright red
+}
+
+func getNotifPalette() notifPalette {
+	if GetTheme() == "terminal" || ResolveTheme() == "terminal" {
+		return terminalNotifColors
+	}
+	return oasisNotifColors
+}
+
+// statusColor returns the tmux fg color string for a given status.
 func statusColor(status Status) string {
+	p := getNotifPalette()
 	switch status {
 	case StatusRunning:
-		return notifGreen
+		return p.Green
 	case StatusWaiting:
-		return notifYellow
+		return p.Yellow
 	case StatusIdle:
-		return notifDim
+		return p.Dim
 	case StatusError:
-		return notifRed
+		return p.Red
 	default:
-		return notifDim
+		return p.Dim
 	}
 }
 
@@ -239,10 +261,11 @@ func (nm *NotificationManager) formatBarMinimal() string {
 		return ""
 	}
 	// Pill: surface bg, primary ⚡, icon counts, then powerline cap back to mantle
+	p := getNotifPalette()
 	pill := fmt.Sprintf("#[bg=%s,fg=%s] ⚡ %s #[bg=%s,fg=%s]\uE0B0#[default]",
-		notifBg, notifAccent,
-		strings.Join(parts, fmt.Sprintf(" #[fg=%s]│ ", notifDim)),
-		notifMantle, notifBg)
+		p.Bg, p.Accent,
+		strings.Join(parts, fmt.Sprintf(" #[fg=%s]│ ", p.Dim)),
+		p.Mantle, p.Bg)
 	return pill
 }
 

--- a/internal/session/notifications_test.go
+++ b/internal/session/notifications_test.go
@@ -711,9 +711,9 @@ func TestMinimalMode_FormatBar_ShowsIconsAndCounts(t *testing.T) {
 	assert.Contains(t, bar, "◐ 1")
 	assert.Contains(t, bar, "○ 1")
 	assert.Contains(t, bar, "│")
-	assert.Contains(t, bar, "#53d390") // running color (oasisGreen)
-	assert.Contains(t, bar, "#f0e68c") // waiting color (oasisYellow)
-	assert.Contains(t, bar, "#8fb0d0") // idle color (oasisDim)
+	assert.Contains(t, bar, "colour10") // running color (bright green)
+	assert.Contains(t, bar, "colour11") // waiting color (bright yellow)
+	assert.Contains(t, bar, "colour7")  // idle color (dim)
 }
 
 // TestMinimalMode_FormatBar_SkipsZeroCounts verifies that statuses with 0 sessions
@@ -762,8 +762,8 @@ func TestMinimalMode_FormatBar_IncludesErrorCount(t *testing.T) {
 
 	assert.Contains(t, bar, "◐ 1")
 	assert.Contains(t, bar, "✕ 2")
-	assert.Contains(t, bar, "#f0e68c") // waiting color (oasisYellow)
-	assert.Contains(t, bar, "#ff7979") // error color (oasisRed)
+	assert.Contains(t, bar, "colour11") // waiting color (bright yellow)
+	assert.Contains(t, bar, "colour9")  // error color (bright red)
 }
 
 // TestMinimalMode_IncludesCurrentSession verifies the current session IS counted in minimal mode.
@@ -782,7 +782,7 @@ func TestMinimalMode_IncludesCurrentSession(t *testing.T) {
 
 	// Both sessions should be counted (● 2)
 	assert.Contains(t, bar, "● 2")
-	assert.Contains(t, bar, "#53d390") // running color (oasisGreen)
+	assert.Contains(t, bar, "colour10") // running color (bright green)
 }
 
 // TestMinimalMode_NoEntries verifies GetEntries returns empty in minimal mode —
@@ -828,6 +828,6 @@ func TestMinimalMode_OnlySingleStatus(t *testing.T) {
 
 	// Only waiting — single group has no │ separator
 	assert.Contains(t, bar, "◐ 3")
-	assert.Contains(t, bar, "#f0e68c") // waiting color (oasisYellow)
+	assert.Contains(t, bar, "colour11") // waiting color (bright yellow)
 	assert.NotContains(t, bar, "│")
 }

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -1081,23 +1081,46 @@ func GetDefaultTool() string {
 	return config.DefaultTool
 }
 
-// GetTheme returns the current theme, defaulting to "dark"
+// ValidThemeNames lists all accepted theme values for config validation.
+var ValidThemeNames = []string{
+	"dark", "light", "system", // backward-compat aliases
+	"oasis-lagoon-dark", "oasis-lagoon-light",
+	"terminal",
+}
+
+// isValidTheme returns true if name is a recognized theme or alias.
+func isValidTheme(name string) bool {
+	for _, v := range ValidThemeNames {
+		if name == v {
+			return true
+		}
+	}
+	return false
+}
+
+// GetTheme returns the current theme, defaulting to "terminal"
 func GetTheme() string {
 	config, err := LoadUserConfig()
 	if err != nil || config == nil {
-		return "dark"
+		return "terminal"
 	}
-	switch config.Theme {
-	case "dark", "light", "system":
+	if isValidTheme(config.Theme) {
 		return config.Theme
-	default:
-		return "dark"
 	}
+	return "terminal"
 }
 
-// ResolveTheme resolves the configured theme to "dark" or "light".
-// If theme is "system", detects the OS dark mode setting.
-// Falls back to "dark" on detection failure.
+// SystemThemeDarkVariant is the theme used when system detects dark mode.
+// SystemThemeLightVariant is the theme used when system detects light mode.
+// These default to the Oasis Lagoon themes for backward compatibility.
+const (
+	SystemThemeDarkVariant  = "oasis-lagoon-dark"
+	SystemThemeLightVariant = "oasis-lagoon-light"
+)
+
+// ResolveTheme resolves the configured theme to a concrete theme name.
+// If theme is "system", detects the OS dark mode setting and returns
+// the default dark/light variant. Otherwise returns the theme as-is.
 func ResolveTheme() string {
 	theme := GetTheme()
 	if theme != "system" {
@@ -1105,12 +1128,12 @@ func ResolveTheme() string {
 	}
 	isDark, err := dark.IsDarkMode()
 	if err != nil {
-		return "dark"
+		return SystemThemeDarkVariant
 	}
 	if isDark {
-		return "dark"
+		return SystemThemeDarkVariant
 	}
-	return "light"
+	return SystemThemeLightVariant
 }
 
 // GetLogSettings returns log management settings with defaults applied

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -253,8 +253,8 @@ func TestGetTheme_Default(t *testing.T) {
 	ClearUserConfigCache()
 
 	theme := GetTheme()
-	if theme != "dark" {
-		t.Errorf("GetTheme: got %q, want %q", theme, "dark")
+	if theme != "terminal" {
+		t.Errorf("GetTheme: got %q, want %q", theme, "terminal")
 	}
 }
 
@@ -265,7 +265,7 @@ func TestGetTheme_Light(t *testing.T) {
 	defer os.Setenv("HOME", originalHome)
 	ClearUserConfigCache()
 
-	// Create config with light theme
+	// Create config with light theme — "light" is a valid alias
 	hangarDir := filepath.Join(tempDir, ".hangar")
 	_ = os.MkdirAll(hangarDir, 0700)
 	config := &UserConfig{Theme: "light"}
@@ -275,6 +275,25 @@ func TestGetTheme_Light(t *testing.T) {
 	theme := GetTheme()
 	if theme != "light" {
 		t.Errorf("GetTheme: got %q, want %q", theme, "light")
+	}
+}
+
+func TestGetTheme_Terminal(t *testing.T) {
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", originalHome)
+	ClearUserConfigCache()
+
+	hangarDir := filepath.Join(tempDir, ".hangar")
+	_ = os.MkdirAll(hangarDir, 0700)
+	config := &UserConfig{Theme: "terminal"}
+	_ = SaveUserConfig(config)
+	ClearUserConfigCache()
+
+	theme := GetTheme()
+	if theme != "terminal" {
+		t.Errorf("GetTheme: got %q, want %q", theme, "terminal")
 	}
 }
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -501,6 +501,10 @@ type Session struct {
 	// When false, the status bar configuration is skipped entirely.
 	// Default: true (set via SetInjectStatusLine from user config)
 	injectStatusLine bool
+
+	// theme controls which color palette ConfigureStatusBar uses.
+	// "terminal" uses ANSI color names; everything else uses Oasis hex.
+	theme string
 }
 
 type envCacheEntry struct {
@@ -603,6 +607,21 @@ func (s *Session) SetInjectStatusLine(inject bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.injectStatusLine = inject
+}
+
+// SetTheme sets the color palette used by ConfigureStatusBar.
+// "terminal" uses ANSI color names; anything else uses Oasis hex.
+func (s *Session) SetTheme(theme string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.theme = theme
+}
+
+// GetTheme returns the configured theme for this session.
+func (s *Session) GetTheme() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.theme
 }
 
 // LogFile returns the path to this session's log file
@@ -1035,22 +1054,64 @@ func (s *Session) Exists() bool {
 	return cmd.Run() == nil
 }
 
-// oasis_lagoon_dark color palette constants used throughout the status bar theme.
-const (
-	oasisCore          = "#101825" // darkest bg (clock fg, active window fg)
-	oasisMantle        = "#1a283f" // status bar bg
-	oasisSurface       = "#22385c" // raised surfaces, inactive windows, notification pill bg
-	oasisPrimary       = "#58b8fd" // active accent / clock bg, notification icon color
-	oasisStrongPrimary = "#1ca0fd" // inactive window fg
-	oasisSecondary     = "#f8b471" // orange — active window tab bg
-	oasisFg            = "#d9e6fa" // foreground text
-	oasisGreen         = "#53d390" // running sessions
-	oasisYellow        = "#f0e68c" // waiting sessions
-	oasisRed           = "#ff7979" // error sessions
-	oasisDim           = "#8fb0d0" // idle / dim text
-)
+// statusBarPalette holds tmux-compatible color strings for the status bar.
+// Values are either hex ("#rrggbb") or tmux ANSI names ("colour12", "default").
+type statusBarPalette struct {
+	Core          string // darkest bg (inverted text fg, active window fg)
+	Mantle        string // status bar bg
+	Surface       string // raised surfaces, inactive windows, notification pill bg
+	Primary       string // active accent / clock bg
+	StrongPrimary string // inactive window fg (brighter accent)
+	Secondary     string // orange — active window tab bg
+	Fg            string // foreground text
+	Green         string // running sessions
+	Yellow        string // waiting sessions
+	Red           string // error sessions
+	Dim           string // idle / dim text
+}
 
-// ConfigureStatusBar sets up the tmux status bar with the oasis_lagoon_dark theme.
+// oasis_lagoon_dark color palette for the status bar.
+var oasisStatusBar = statusBarPalette{
+	Core:          "#101825",
+	Mantle:        "#1a283f",
+	Surface:       "#22385c",
+	Primary:       "#58b8fd",
+	StrongPrimary: "#1ca0fd",
+	Secondary:     "#f8b471",
+	Fg:            "#d9e6fa",
+	Green:         "#53d390",
+	Yellow:        "#f0e68c",
+	Red:           "#ff7979",
+	Dim:           "#8fb0d0",
+}
+
+// Terminal-adaptive palette: uses tmux ANSI color names so the status bar
+// follows the terminal's theme (Tokyo Night, Catppuccin, Gruvbox, etc.).
+// "default" means inherit the terminal's default bg/fg.
+var terminalStatusBar = statusBarPalette{
+	Core:          "colour0",   // ANSI black (dark text on colored bg)
+	Mantle:        "default",   // terminal default background
+	Surface:       "colour0",   // ANSI black — close to terminal bg, subtle elevation
+	Primary:       "colour12",  // bright blue (accent)
+	StrongPrimary: "colour4",   // blue (slightly dimmer accent)
+	Secondary:     "colour3",   // yellow (closest to orange in ANSI)
+	Fg:            "colour15",  // bright white (primary text)
+	Green:         "colour10",  // bright green
+	Yellow:        "colour11",  // bright yellow
+	Red:           "colour9",   // bright red
+	Dim:           "colour7",   // white (mid-gray dim text)
+}
+
+// getStatusBarPalette returns the palette to use based on the theme name.
+func getStatusBarPalette(theme string) statusBarPalette {
+	if theme == "terminal" {
+		return terminalStatusBar
+	}
+	return oasisStatusBar
+}
+
+// ConfigureStatusBar sets up the tmux status bar theme.
+// Uses Oasis Lagoon hex colors by default, or ANSI terminal colors when theme="terminal".
 //
 // Layout:
 //   - status-left:  managed by NotificationManager (hangar session icons)
@@ -1065,45 +1126,33 @@ func (s *Session) ConfigureStatusBar() {
 		return
 	}
 
-	// oasis_lagoon_dark powerline status-right:
-	//   [session-name pill] [folder pill] [clock pill]
-	//
-	// Powerline transitions use a block char (█) to fake a capsule edge with a
-	// contrasting background.  The sequence is:
-	//   <surface-bg> session name  <primary-bg><core-fg> folder  <core-bg><primary-fg> HH:MM
-	//
-	// Each pill is padded with one space on each side for breathing room.
-	rightStatus := "" +
-		// Session name pill: surface bg, fg color, bold
-		fmt.Sprintf("#[bg=%s,fg=%s,bold] %s #[nobold]", oasisSurface, oasisPrimary, s.DisplayName) +
-		// Transition: surface→mantle then folder pill bg starts
-		fmt.Sprintf("#[bg=%s,fg=%s]\uE0B0#[bg=%s,fg=%s] #{b:pane_current_path} ", oasisMantle, oasisSurface, oasisMantle, oasisFg) +
-		// Transition: mantle→surface (clock pill - matches session name pill)
-		fmt.Sprintf("#[fg=%s]\uE0B0#[bg=%s,fg=%s,bold] %%H:%%M #[nobold]", oasisSurface, oasisSurface, oasisPrimary)
+	p := getStatusBarPalette(s.theme)
 
-	// Inactive window tab: rounded pill using powerline caps (U+E0B6 left, U+E0B4 right).
-	// Cap fg = pill bg so the rounded cap blends into the mantle status-bar bg.
+	// Powerline status-right:
+	//   [session-name pill] [folder pill] [clock pill]
+	rightStatus := "" +
+		fmt.Sprintf("#[bg=%s,fg=%s,bold] %s #[nobold]", p.Surface, p.Primary, s.DisplayName) +
+		fmt.Sprintf("#[bg=%s,fg=%s]\uE0B0#[bg=%s,fg=%s] #{b:pane_current_path} ", p.Mantle, p.Surface, p.Mantle, p.Fg) +
+		fmt.Sprintf("#[fg=%s]\uE0B0#[bg=%s,fg=%s,bold] %%H:%%M #[nobold]", p.Surface, p.Surface, p.Primary)
+
+	// Inactive window tab: rounded pill using powerline caps
 	winInactive := "" +
-		fmt.Sprintf("#[bg=%s,fg=%s]\uE0B6", oasisMantle, oasisSurface) +
-		fmt.Sprintf("#[bg=%s,fg=%s] #I #W ", oasisSurface, oasisStrongPrimary) +
-		fmt.Sprintf("#[bg=%s,fg=%s]\uE0B4", oasisMantle, oasisSurface)
-	// Active window tab: orange pill, bold text
+		fmt.Sprintf("#[bg=%s,fg=%s]\uE0B6", p.Mantle, p.Surface) +
+		fmt.Sprintf("#[bg=%s,fg=%s] #I #W ", p.Surface, p.StrongPrimary) +
+		fmt.Sprintf("#[bg=%s,fg=%s]\uE0B4", p.Mantle, p.Surface)
+	// Active window tab: accent pill, bold text
 	winActive := "" +
-		fmt.Sprintf("#[bg=%s,fg=%s]\uE0B6", oasisMantle, oasisSecondary) +
-		fmt.Sprintf("#[bg=%s,fg=%s,bold] #I #W #[nobold]", oasisSecondary, oasisCore) +
-		fmt.Sprintf("#[bg=%s,fg=%s]\uE0B4", oasisMantle, oasisSecondary)
+		fmt.Sprintf("#[bg=%s,fg=%s]\uE0B6", p.Mantle, p.Secondary) +
+		fmt.Sprintf("#[bg=%s,fg=%s,bold] #I #W #[nobold]", p.Secondary, p.Core) +
+		fmt.Sprintf("#[bg=%s,fg=%s]\uE0B4", p.Mantle, p.Secondary)
 
 	// PERFORMANCE: Batch all status bar options into a single subprocess call.
-	// Uses tmux command chaining with ; separator (reduces subprocess spawns).
 	cmd := exec.Command("tmux",
-		// Global status bar appearance
 		"set-option", "-t", s.Name, "status", "on", ";",
-		"set-option", "-t", s.Name, "status-style", fmt.Sprintf("bg=%s,fg=%s", oasisMantle, oasisFg), ";",
+		"set-option", "-t", s.Name, "status-style", fmt.Sprintf("bg=%s,fg=%s", p.Mantle, p.Fg), ";",
 		"set-option", "-t", s.Name, "status-left-length", "120", ";",
 		"set-option", "-t", s.Name, "status-right-length", "120", ";",
-		// Right side: session + folder + clock pills
 		"set-option", "-t", s.Name, "status-right", rightStatus, ";",
-		// Window tabs
 		"set-window-option", "-t", s.Name, "window-status-format", winInactive, ";",
 		"set-window-option", "-t", s.Name, "window-status-current-format", winActive, ";",
 		"set-window-option", "-t", s.Name, "window-status-separator", "")

--- a/internal/ui/confirm_dialog.go
+++ b/internal/ui/confirm_dialog.go
@@ -169,7 +169,7 @@ func (c *ConfirmDialog) View() string {
 	// Build warning message and buttons based on action type
 	var title, warning, details string
 	var buttons string
-	var borderColor lipgloss.Color
+	var borderColor lipgloss.TerminalColor
 
 	// Styles (shared)
 	detailsStyle := lipgloss.NewStyle().
@@ -184,13 +184,13 @@ func (c *ConfirmDialog) View() string {
 		borderColor = ColorRed
 
 		buttonYes := lipgloss.NewStyle().
-			Foreground(ColorBg).
+			Foreground(ColorInvertFg).
 			Background(ColorRed).
 			Padding(0, 2).
 			Bold(true).
 			Render("y Delete")
 		buttonNo := lipgloss.NewStyle().
-			Foreground(ColorBg).
+			Foreground(ColorInvertFg).
 			Background(ColorAccent).
 			Padding(0, 2).
 			Bold(true).
@@ -207,13 +207,13 @@ func (c *ConfirmDialog) View() string {
 		borderColor = ColorRed
 
 		buttonYes := lipgloss.NewStyle().
-			Foreground(ColorBg).
+			Foreground(ColorInvertFg).
 			Background(ColorRed).
 			Padding(0, 2).
 			Bold(true).
 			Render("y Delete")
 		buttonNo := lipgloss.NewStyle().
-			Foreground(ColorBg).
+			Foreground(ColorInvertFg).
 			Background(ColorAccent).
 			Padding(0, 2).
 			Bold(true).
@@ -231,13 +231,13 @@ func (c *ConfirmDialog) View() string {
 
 		// "Keep running" is the default (green), "Shut down" is secondary (red)
 		buttonKeep := lipgloss.NewStyle().
-			Foreground(ColorBg).
+			Foreground(ColorInvertFg).
 			Background(ColorGreen).
 			Padding(0, 2).
 			Bold(true).
 			Render("k Keep running")
 		buttonShutdown := lipgloss.NewStyle().
-			Foreground(ColorBg).
+			Foreground(ColorInvertFg).
 			Background(ColorRed).
 			Padding(0, 2).
 			Bold(true).
@@ -254,13 +254,13 @@ func (c *ConfirmDialog) View() string {
 		borderColor = ColorAccent
 
 		buttonYes := lipgloss.NewStyle().
-			Foreground(ColorBg).
+			Foreground(ColorInvertFg).
 			Background(ColorGreen).
 			Padding(0, 2).
 			Bold(true).
 			Render("y Create")
 		buttonNo := lipgloss.NewStyle().
-			Foreground(ColorBg).
+			Foreground(ColorInvertFg).
 			Background(ColorRed).
 			Padding(0, 2).
 			Bold(true).
@@ -277,13 +277,13 @@ func (c *ConfirmDialog) View() string {
 		borderColor = ColorAccent
 
 		buttonYes := lipgloss.NewStyle().
-			Foreground(ColorBg).
+			Foreground(ColorInvertFg).
 			Background(ColorGreen).
 			Padding(0, 2).
 			Bold(true).
 			Render("y Install")
 		buttonNo := lipgloss.NewStyle().
-			Foreground(ColorBg).
+			Foreground(ColorInvertFg).
 			Background(ColorAccent).
 			Padding(0, 2).
 			Bold(true).
@@ -314,10 +314,10 @@ func (c *ConfirmDialog) View() string {
 		borderColor = ColorRed
 
 		buttonYes := lipgloss.NewStyle().
-			Foreground(ColorBg).Background(ColorRed).Padding(0, 2).Bold(true).
+			Foreground(ColorInvertFg).Background(ColorRed).Padding(0, 2).Bold(true).
 			Render(fmt.Sprintf("y Delete %s", c.targetName))
 		buttonNo := lipgloss.NewStyle().
-			Foreground(ColorBg).Background(ColorAccent).Padding(0, 2).Bold(true).
+			Foreground(ColorInvertFg).Background(ColorAccent).Padding(0, 2).Bold(true).
 			Render("n Cancel")
 		escHint := lipgloss.NewStyle().Foreground(ColorTextDim).Render("(Esc to cancel)")
 		buttons = lipgloss.JoinHorizontal(lipgloss.Center, buttonYes, "  ", buttonNo, "  ", escHint)
@@ -329,10 +329,10 @@ func (c *ConfirmDialog) View() string {
 		borderColor = ColorAccent
 
 		buttonYes := lipgloss.NewStyle().
-			Foreground(ColorBg).Background(ColorAccent).Padding(0, 2).Bold(true).
+			Foreground(ColorInvertFg).Background(ColorAccent).Padding(0, 2).Bold(true).
 			Render("y Restart")
 		buttonNo := lipgloss.NewStyle().
-			Foreground(ColorBg).Background(ColorRed).Padding(0, 2).Bold(true).
+			Foreground(ColorInvertFg).Background(ColorRed).Padding(0, 2).Bold(true).
 			Render("n Cancel")
 		escHint := lipgloss.NewStyle().Foreground(ColorTextDim).Render("(Esc to cancel)")
 		buttons = lipgloss.JoinHorizontal(lipgloss.Center, buttonYes, "  ", buttonNo, "  ", escHint)

--- a/internal/ui/global_search.go
+++ b/internal/ui/global_search.go
@@ -24,7 +24,7 @@ var (
 	globalSelectedStyle = lipgloss.NewStyle().
 				Padding(0, 2).
 				Background(ColorCyan).
-				Foreground(ColorBg)
+				Foreground(ColorInvertFg)
 
 	globalSearchHeaderStyle = lipgloss.NewStyle().
 				Foreground(ColorCyan).
@@ -32,7 +32,7 @@ var (
 
 	highlightStyle = lipgloss.NewStyle().
 			Background(ColorYellow).
-			Foreground(ColorBg).
+			Foreground(ColorInvertFg).
 			Bold(true)
 )
 
@@ -556,7 +556,7 @@ func (gs *GlobalSearch) formatPreviewContent(content string, maxWidth int) []str
 
 		// Determine base style and prefix for user vs assistant messages
 		var prefix string
-		var baseColor lipgloss.Color
+		var baseColor lipgloss.TerminalColor
 		if strings.HasPrefix(rawLine, "User:") || strings.HasPrefix(rawLine, "[User]") {
 			prefix = "👤 "
 			rawLine = strings.TrimPrefix(strings.TrimPrefix(rawLine, "User:"), "[User]")

--- a/internal/ui/group_dialog.go
+++ b/internal/ui/group_dialog.go
@@ -353,7 +353,7 @@ func (g *GroupDialog) View() string {
 			}
 			if i == g.selected {
 				b.WriteString(lipgloss.NewStyle().
-					Foreground(ColorBg).
+					Foreground(ColorInvertFg).
 					Background(ColorAccent).
 					Bold(true).
 					Padding(0, 1).

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -2574,9 +2574,9 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h, h.loadSessions
 
 	case systemThemeMsg:
-		theme := "light"
+		theme := session.SystemThemeLightVariant
 		if msg.dark {
-			theme = "dark"
+			theme = session.SystemThemeDarkVariant
 		}
 		InitTheme(theme)
 		// IMPORTANT: Re-issue listener to keep watching for theme changes.
@@ -5989,7 +5989,7 @@ func (h *Home) countSessionStatuses() (running, waiting, idle, errored int) {
 // renderPill renders a single-line terminal pill using Nerd Font powerline caps.
 // barBg is the background color of the row the pill sits on; cap fg is set to
 // pillBg so the cap blends into the surrounding row background.
-func renderPill(label string, textFg, pillBg, barBg lipgloss.Color, bold bool) string {
+func renderPill(label string, textFg, pillBg, barBg lipgloss.TerminalColor, bold bool) string {
 	capL := lipgloss.NewStyle().Foreground(pillBg).Background(barBg).Render("\uE0B6")
 	body := lipgloss.NewStyle().Foreground(textFg).Background(pillBg).Bold(bold).Render(" " + label + " ")
 	capR := lipgloss.NewStyle().Foreground(pillBg).Background(barBg).Render("\uE0B4")
@@ -6041,7 +6041,7 @@ func (h *Home) renderNavTabs() string {
 	for i, tab := range tabs {
 		var rendered string
 		if h.viewMode == tab.mode {
-			rendered = renderPill(tab.label, ColorBg, ColorAccent, ColorBg, true)
+			rendered = renderPill(tab.label, ColorInvertFg, ColorAccent, ColorBg, true)
 		} else {
 			rendered = lipgloss.NewStyle().Foreground(ColorComment).Padding(0, 1).Render(tab.label)
 		}
@@ -6105,15 +6105,15 @@ func (h *Home) renderFilterBar() string {
 		var rendered string
 		switch {
 		case isActive && d.status == "":
-			rendered = renderPill(label, ColorBg, ColorAccent, ColorBg, true)
+			rendered = renderPill(label, ColorInvertFg, ColorAccent, ColorBg, true)
 		case isActive && d.status == session.StatusRunning:
-			rendered = renderPill(label, ColorBg, ColorGreen, ColorBg, true)
+			rendered = renderPill(label, ColorInvertFg, ColorGreen, ColorBg, true)
 		case isActive && d.status == session.StatusWaiting:
-			rendered = renderPill(label, ColorBg, ColorYellow, ColorBg, true)
+			rendered = renderPill(label, ColorInvertFg, ColorYellow, ColorBg, true)
 		case isActive && d.status == session.StatusIdle:
-			rendered = renderPill(label, ColorBg, ColorTextDim, ColorBg, true)
+			rendered = renderPill(label, ColorInvertFg, ColorTextDim, ColorBg, true)
 		case isActive && d.status == session.StatusError:
-			rendered = renderPill(label, ColorBg, ColorRed, ColorBg, true)
+			rendered = renderPill(label, ColorInvertFg, ColorRed, ColorBg, true)
 		default:
 			// Inactive: plain styled text with count — no powerline caps to avoid visual noise
 			switch d.status {
@@ -6150,7 +6150,7 @@ func (h *Home) renderFilterBar() string {
 
 	// Sort mode indicator
 	if h.sortMode == "status" {
-		pills = append(pills, renderPill("⇅ sorted", ColorBg, ColorAccent, ColorBg, true))
+		pills = append(pills, renderPill("⇅ sorted", ColorInvertFg, ColorAccent, ColorBg, true))
 	}
 
 	filterRow := " " + strings.Join(pills, " ")
@@ -6309,7 +6309,7 @@ func (h *Home) View() string {
 	if h.updateInfo != nil && h.updateInfo.Available {
 		updateBannerHeight = 1
 		updateStyle := lipgloss.NewStyle().
-			Foreground(ColorBg).
+			Foreground(ColorInvertFg).
 			Background(ColorYellow).
 			Bold(true).
 			MaxWidth(h.width).
@@ -6327,7 +6327,7 @@ func (h *Home) View() string {
 	if h.maintenanceMsg != "" {
 		maintenanceBannerHeight = 1
 		maintStyle := lipgloss.NewStyle().
-			Foreground(ColorBg).
+			Foreground(ColorInvertFg).
 			Background(ColorCyan).
 			Bold(true).
 			MaxWidth(h.width).
@@ -6832,7 +6832,7 @@ func (h *Home) renderHelpBarMinimal() string {
 	border := borderStyle.Render(strings.Repeat("─", max(0, h.width)))
 
 	keyStyle := lipgloss.NewStyle().
-		Foreground(ColorBg).
+		Foreground(ColorInvertFg).
 		Background(ColorAccent).
 		Bold(true)
 	sepStyle := lipgloss.NewStyle().Foreground(ColorBorder)
@@ -6961,7 +6961,7 @@ func (h *Home) renderHelpBarCompact() string {
 // helpKeyShort formats a compact keyboard shortcut (no padding)
 func (h *Home) helpKeyShort(key, desc string) string {
 	keyStyle := lipgloss.NewStyle().
-		Foreground(ColorBg).
+		Foreground(ColorInvertFg).
 		Background(ColorAccent).
 		Bold(true)
 	descStyle := lipgloss.NewStyle().Foreground(ColorText)
@@ -7104,7 +7104,7 @@ func (h *Home) renderHelpBarBulkMode() string {
 	border := borderStyle.Render(strings.Repeat("─", max(0, h.width)))
 
 	keyStyle := lipgloss.NewStyle().
-		Foreground(ColorBg).
+		Foreground(ColorInvertFg).
 		Background(ColorAccent).
 		Bold(true)
 	dimStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
@@ -7170,7 +7170,7 @@ func (h *Home) renderPROverview() string {
 
 	// ── Tab bar ──────────────────────────────────────────────────────────
 	tabNames := []string{"All", "Mine", "Review Requests", "Sessions"}
-	activeTabStyle := lipgloss.NewStyle().Foreground(ColorBg).Background(ColorAccent).Bold(true).Padding(0, 1)
+	activeTabStyle := lipgloss.NewStyle().Foreground(ColorInvertFg).Background(ColorAccent).Bold(true).Padding(0, 1)
 	inactiveTabStyle := lipgloss.NewStyle().Foreground(ColorComment).Padding(0, 1)
 	var tabParts []string
 	for i, name := range tabNames {
@@ -7467,7 +7467,7 @@ func (h *Home) renderPROverview() string {
 // helpKey formats a keyboard shortcut for the help bar
 func (h *Home) helpKey(key, desc string) string {
 	keyStyle := lipgloss.NewStyle().
-		Foreground(ColorBg).
+		Foreground(ColorInvertFg).
 		Background(ColorAccent).
 		Bold(true).
 		Padding(0, 1)

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -752,7 +752,7 @@ func (d *NewDialog) View() string {
 		if i == d.commandCursor {
 			// Selected: bright background, bold (active pill)
 			btnStyle = lipgloss.NewStyle().
-				Foreground(ColorBg).
+				Foreground(ColorInvertFg).
 				Background(ColorAccent).
 				Bold(true).
 				Padding(0, 2)

--- a/internal/ui/preview_renderer.go
+++ b/internal/ui/preview_renderer.go
@@ -362,7 +362,7 @@ func (h *Home) renderSessionInfoCard(inst *session.Instance, width, height int) 
 	b.WriteString(fmt.Sprintf("%s %s\n", stylePreviewLabelDim.Render("Path:"), stylePreviewLabel.Render(inst.ProjectPath)))
 
 	// Status with color (runtime-dependent — must stay inline)
-	var statusColor lipgloss.Color
+	var statusColor lipgloss.TerminalColor
 	switch cardStatus {
 	case session.StatusRunning:
 		statusColor = ColorGreen

--- a/internal/ui/search.go
+++ b/internal/ui/search.go
@@ -22,7 +22,7 @@ var (
 	selectedResultStyle = lipgloss.NewStyle().
 				Padding(0, 2).
 				Background(ColorAccent).
-				Foreground(ColorBg)
+				Foreground(ColorInvertFg)
 
 	overlayStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -70,8 +70,16 @@ var toolNames = []string{"Claude", "Shell", "None"}
 var toolValues = []string{"claude", "shell", ""}
 
 // Theme names for radio selection
-var themeNames = []string{"Dark", "Light", "System"}
-var themeValues = []string{"dark", "light", "system"}
+var themeNames = []string{
+	"Oasis Dark", "Oasis Light",
+	"Terminal",
+	"System",
+}
+var themeValues = []string{
+	"oasis-lagoon-dark", "oasis-lagoon-light",
+	"terminal",
+	"system",
+}
 
 // NewSettingsPanel creates a new settings panel
 func NewSettingsPanel() *SettingsPanel {
@@ -130,14 +138,19 @@ func (s *SettingsPanel) SetProfile(profile string) {
 
 // LoadConfig populates panel values from a UserConfig
 func (s *SettingsPanel) LoadConfig(config *session.UserConfig) {
-	// Load theme
-	switch config.Theme {
-	case "light":
-		s.selectedTheme = 1
-	case "system":
-		s.selectedTheme = 2
-	default:
+	// Load theme — find index in themeValues, default to 0 (Oasis Dark)
+	s.selectedTheme = 0
+	for i, v := range themeValues {
+		if config.Theme == v {
+			s.selectedTheme = i
+			break
+		}
+	}
+	// Backward-compat: "dark" and "light" map to oasis variants
+	if config.Theme == "dark" {
 		s.selectedTheme = 0
+	} else if config.Theme == "light" {
+		s.selectedTheme = 1
 	}
 
 	// Default tool

--- a/internal/ui/settings_panel_test.go
+++ b/internal/ui/settings_panel_test.go
@@ -508,28 +508,28 @@ func containsSubstring(s, substr string) bool {
 
 func TestSettingsPanel_ThemeToggle(t *testing.T) {
 	panel := NewSettingsPanel()
-	// Set dark explicitly (avoid loading config from disk)
+	// Set oasis-dark explicitly (avoid loading config from disk)
 	panel.selectedTheme = 0
 	panel.visible = true
 
-	// Navigate right to select light
+	// Navigate right to select oasis-light
 	panel.cursor = int(SettingTheme)
 	panel, _, shouldSave := panel.Update(tea.KeyMsg{Type: tea.KeyRight})
 
 	if panel.selectedTheme != 1 {
-		t.Errorf("Theme should be 1 (light) after right, got %d", panel.selectedTheme)
+		t.Errorf("Theme should be 1 (oasis-lagoon-light) after right, got %d", panel.selectedTheme)
 	}
 	if !shouldSave {
 		t.Error("Should trigger save on theme change")
 	}
 
-	// Navigate right to select system
+	// Navigate right to select tokyonight-night
 	panel, _, shouldSave = panel.Update(tea.KeyMsg{Type: tea.KeyRight})
 	if panel.selectedTheme != 2 {
-		t.Errorf("Theme should be 2 (system) after right, got %d", panel.selectedTheme)
+		t.Errorf("Theme should be 2 (tokyonight-night) after right, got %d", panel.selectedTheme)
 	}
 	if !shouldSave {
-		t.Error("Should trigger save on theme change to system")
+		t.Error("Should trigger save on theme change")
 	}
 
 	// Theme changes should not require restart (applied live)
@@ -544,11 +544,14 @@ func TestSettingsPanel_LoadConfig_Theme(t *testing.T) {
 		theme    string
 		expected int
 	}{
-		{"dark", "dark", 0},
-		{"light", "light", 1},
-		{"system", "system", 2},
-		{"empty defaults to dark", "", 0},
-		{"invalid defaults to dark", "invalid", 0},
+		{"oasis-lagoon-dark", "oasis-lagoon-dark", 0},
+		{"oasis-lagoon-light", "oasis-lagoon-light", 1},
+		{"terminal", "terminal", 2},
+		{"system", "system", 3},
+		{"dark alias", "dark", 0},
+		{"light alias", "light", 1},
+		{"empty defaults to oasis dark", "", 0},
+		{"invalid defaults to oasis dark", "invalid", 0},
 	}
 
 	for _, tt := range tests {
@@ -570,9 +573,10 @@ func TestSettingsPanel_GetConfig_Theme(t *testing.T) {
 		selectedTheme int
 		expected      string
 	}{
-		{"dark", 0, "dark"},
-		{"light", 1, "light"},
-		{"system", 2, "system"},
+		{"oasis-lagoon-dark", 0, "oasis-lagoon-dark"},
+		{"oasis-lagoon-light", 1, "oasis-lagoon-light"},
+		{"terminal", 2, "terminal"},
+		{"system", 3, "system"},
 	}
 
 	for _, tt := range tests {

--- a/internal/ui/setup_wizard.go
+++ b/internal/ui/setup_wizard.go
@@ -30,7 +30,7 @@ type SetupWizard struct {
 	claudeSettingsCursor int // 0=dangerous mode, 1=config dir
 
 	// Theme setting
-	selectedTheme int // 0=dark, 1=light
+	selectedTheme int // index into themeValues
 }
 
 // Wizard steps
@@ -176,11 +176,11 @@ func (w *SetupWizard) GetConfig() *session.UserConfig {
 		Minimal:  true,
 	}
 
-	// Theme (defaults to dark)
-	if w.selectedTheme == 1 {
-		config.Theme = "light"
+	// Theme (defaults to oasis-lagoon-dark)
+	if w.selectedTheme >= 0 && w.selectedTheme < len(themeValues) {
+		config.Theme = themeValues[w.selectedTheme]
 	} else {
-		config.Theme = "dark"
+		config.Theme = themeValues[0]
 	}
 
 	return config
@@ -281,7 +281,7 @@ func (w *SetupWizard) View() string {
 		Foreground(ColorText)
 
 	selectedStyle := lipgloss.NewStyle().
-		Foreground(ColorBg).
+		Foreground(ColorInvertFg).
 		Background(ColorAccent).
 		Bold(true).
 		Padding(0, 1)

--- a/internal/ui/setup_wizard_test.go
+++ b/internal/ui/setup_wizard_test.go
@@ -298,7 +298,8 @@ func TestSetupWizard_GetConfig_DefaultTheme(t *testing.T) {
 	wizard := NewSetupWizard()
 	config := wizard.GetConfig()
 
-	if config.Theme != "dark" {
-		t.Errorf("Default theme should be 'dark', got %q", config.Theme)
+	if config.Theme != "oasis-lagoon-dark" {
+		// Default wizard selectedTheme=0 maps to themeValues[0] which is "oasis-lagoon-dark"
+		t.Errorf("Default wizard theme should be 'oasis-lagoon-dark', got %q", config.Theme)
 	}
 }

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -11,113 +11,170 @@ import (
 type Theme string
 
 const (
-	ThemeDark  Theme = "dark"
-	ThemeLight Theme = "light"
+	ThemeOasisLagoonDark  Theme = "oasis-lagoon-dark"
+	ThemeOasisLagoonLight Theme = "oasis-lagoon-light"
+
+	// Backward-compat aliases (used internally for system theme resolution)
+	ThemeDark  = ThemeOasisLagoonDark
+	ThemeLight = ThemeOasisLagoonLight
 )
+
+// colorPalette holds the semantic color slots for a theme.
+// Fields use lipgloss.TerminalColor so palettes can mix hex (lipgloss.Color),
+// ANSI palette slots (lipgloss.ANSIColor), and transparent (lipgloss.NoColor).
+type colorPalette struct {
+	Bg, Surface, Border, Text, TextDim  lipgloss.TerminalColor
+	Accent, Purple, Cyan, Green, Yellow lipgloss.TerminalColor
+	Orange, Red, Comment                lipgloss.TerminalColor
+
+	// InvertFg is the foreground color for inverted/highlighted elements
+	// (e.g. dark text on colored badge/pill/selection background).
+	// For hex themes this equals Bg. For the terminal theme it is ANSIColor(0)
+	// because Bg is NoColor{} (transparent) which can't be used as foreground.
+	InvertFg lipgloss.TerminalColor
+}
 
 // currentTheme holds the active theme (set at init)
 var currentTheme Theme = ThemeDark
 
-// Dark Theme - Oasis Lagoon
-var darkColors = struct {
-	Bg, Surface, Border, Text, TextDim  lipgloss.Color
-	Accent, Purple, Cyan, Green, Yellow lipgloss.Color
-	Orange, Red, Comment                lipgloss.Color
-}{
-	Bg:      lipgloss.Color("#101825"), // bg.core
-	Surface: lipgloss.Color("#22385C"), // bg.surface
-	Border:  lipgloss.Color("#264870"), // mid-navy
-	Text:    lipgloss.Color("#D9E6FA"), // fg.core
-	TextDim: lipgloss.Color("#8FB0D0"), // blue-gray dim
-	Accent:  lipgloss.Color("#58B8FD"), // lagoon primary blue
-	Purple:  lipgloss.Color("#C695FF"), // terminal magenta
-	Cyan:    lipgloss.Color("#68C0B6"), // terminal cyan/teal
-	Green:   lipgloss.Color("#53D390"), // cactus green
-	Yellow:  lipgloss.Color("#F0E68C"), // khaki
-	Orange:  lipgloss.Color("#F8B471"), // sunrise orange
-	Red:     lipgloss.Color("#FF7979"), // terminal red
-	Comment: lipgloss.Color("#4D88A7"), // fg.comment
+// hex is shorthand for lipgloss.Color in palette definitions.
+func hex(s string) lipgloss.TerminalColor { return lipgloss.Color(s) }
+
+// ansi is shorthand for lipgloss.ANSIColor in palette definitions.
+func ansi(n int) lipgloss.TerminalColor { return lipgloss.ANSIColor(n) }
+
+// ── Oasis Lagoon (original) ─────────────────────────────────────────
+
+var oasisLagoonDark = colorPalette{
+	Bg:       hex("#101825"), // bg.core
+	InvertFg: hex("#101825"), // same as Bg
+	Surface:  hex("#22385C"), // bg.surface
+	Border:   hex("#264870"), // mid-navy
+	Text:     hex("#D9E6FA"), // fg.core
+	TextDim:  hex("#8FB0D0"), // blue-gray dim
+	Accent:   hex("#58B8FD"), // lagoon primary blue
+	Purple:   hex("#C695FF"), // terminal magenta
+	Cyan:     hex("#68C0B6"), // terminal cyan/teal
+	Green:    hex("#53D390"), // cactus green
+	Yellow:   hex("#F0E68C"), // khaki
+	Orange:   hex("#F8B471"), // sunrise orange
+	Red:      hex("#FF7979"), // terminal red
+	Comment:  hex("#4D88A7"), // fg.comment
 }
 
-// Light Theme - Oasis Dawn
-// Derived from oasis.nvim palette: light_terminal colors + lagoon/teal numeric scales
-var lightColors = struct {
-	Bg, Surface, Border, Text, TextDim  lipgloss.Color
-	Accent, Purple, Cyan, Green, Yellow lipgloss.Color
-	Orange, Red, Comment                lipgloss.Color
-}{
-	Bg:      lipgloss.Color("#EEF4FF"), // lagoon[50] - lightest lagoon tint
-	Surface: lipgloss.Color("#D0E8FE"), // lagoon[100] - soft blue surface
-	Border:  lipgloss.Color("#B2DCFE"), // lagoon[200] - medium lagoon border
-	Text:    lipgloss.Color("#10426d"), // light_terminal.bright_blue - dark navy text
-	TextDim: lipgloss.Color("#1f3f71"), // light_terminal.bright_blue variant
-	Accent:  lipgloss.Color("#1670AD"), // lagoon[800] - medium lagoon accent
-	Purple:  lipgloss.Color("#46259f"), // light_terminal.magenta
-	Cyan:    lipgloss.Color("#064658"), // light_terminal.cyan
-	Green:   lipgloss.Color("#1b491d"), // light_terminal.green
-	Yellow:  lipgloss.Color("#6b2e00"), // light_terminal.yellow
-	Orange:  lipgloss.Color("#533c00"), // light_terminal.bright_yellow
-	Red:     lipgloss.Color("#663021"), // light_terminal.red
-	Comment: lipgloss.Color("#0D4266"), // lagoon[900] - deep lagoon comment
+var oasisLagoonLight = colorPalette{
+	Bg:       hex("#EEF4FF"), // lagoon[50] - lightest lagoon tint
+	InvertFg: hex("#EEF4FF"), // same as Bg
+	Surface:  hex("#D0E8FE"), // lagoon[100] - soft blue surface
+	Border:   hex("#B2DCFE"), // lagoon[200] - medium lagoon border
+	Text:     hex("#10426d"), // light_terminal.bright_blue - dark navy text
+	TextDim:  hex("#1f3f71"), // light_terminal.bright_blue variant
+	Accent:   hex("#1670AD"), // lagoon[800] - medium lagoon accent
+	Purple:   hex("#46259f"), // light_terminal.magenta
+	Cyan:     hex("#064658"), // light_terminal.cyan
+	Green:    hex("#1b491d"), // light_terminal.green
+	Yellow:   hex("#6b2e00"), // light_terminal.yellow
+	Orange:   hex("#533c00"), // light_terminal.bright_yellow
+	Red:      hex("#663021"), // light_terminal.red
+	Comment:  hex("#0D4266"), // lagoon[900] - deep lagoon comment
+}
+
+// ── Terminal Adaptive ───────────────────────────────────────────────
+// Uses ANSI palette slots 0-15 so colors follow the terminal's theme.
+// Change your terminal theme (Tokyo Night, Catppuccin, Gruvbox, etc.)
+// and Hangar adapts automatically.
+
+const ThemeTerminal Theme = "terminal"
+
+var terminalAdaptive = colorPalette{
+	Bg:       lipgloss.NoColor{}, // transparent — terminal bg shows through
+	InvertFg: ansi(0),            // ANSI black — dark text on colored backgrounds
+	Surface:  lipgloss.NoColor{}, // transparent — no distinct elevation
+	Border:   ansi(8),            // bright black — universally a muted gray
+	Text:    ansi(15), // bright white — primary foreground
+	TextDim: ansi(7),  // white (normal) — mid-gray in dark themes
+	Accent:  ansi(12), // bright blue — primary accent
+	Purple:  ansi(13), // bright magenta
+	Cyan:    ansi(14), // bright cyan
+	Green:   ansi(10), // bright green
+	Yellow:  ansi(11), // bright yellow (often orange-ish in themes)
+	Orange:  ansi(3),  // yellow (normal) — closest to orange in ANSI
+	Red:     ansi(9),  // bright red
+	Comment: ansi(8),  // bright black — muted/comment text
+}
+
+// palettes maps theme names to their color palette.
+var palettes = map[Theme]colorPalette{
+	ThemeOasisLagoonDark:  oasisLagoonDark,
+	ThemeOasisLagoonLight: oasisLagoonLight,
+	ThemeTerminal:         terminalAdaptive,
+}
+
+// Backward-compat: old names that users may have in config.toml
+var themeAliases = map[string]Theme{
+	"dark":  ThemeOasisLagoonDark,
+	"light": ThemeOasisLagoonLight,
 }
 
 // Active color variables (set by InitTheme)
 var (
-	ColorBg      lipgloss.Color
-	ColorSurface lipgloss.Color
-	ColorBorder  lipgloss.Color
-	ColorText    lipgloss.Color
-	ColorTextDim lipgloss.Color
-	ColorAccent  lipgloss.Color
-	ColorPurple  lipgloss.Color
-	ColorCyan    lipgloss.Color
-	ColorGreen   lipgloss.Color
-	ColorYellow  lipgloss.Color
-	ColorOrange  lipgloss.Color
-	ColorRed     lipgloss.Color
-	ColorComment lipgloss.Color
+	ColorBg       lipgloss.TerminalColor
+	ColorInvertFg lipgloss.TerminalColor // dark text for inverted/highlighted elements
+	ColorSurface  lipgloss.TerminalColor
+	ColorBorder  lipgloss.TerminalColor
+	ColorText    lipgloss.TerminalColor
+	ColorTextDim lipgloss.TerminalColor
+	ColorAccent  lipgloss.TerminalColor
+	ColorPurple  lipgloss.TerminalColor
+	ColorCyan    lipgloss.TerminalColor
+	ColorGreen   lipgloss.TerminalColor
+	ColorYellow  lipgloss.TerminalColor
+	ColorOrange  lipgloss.TerminalColor
+	ColorRed     lipgloss.TerminalColor
+	ColorComment lipgloss.TerminalColor
 )
 
 // themeMu protects global color/style variables during live theme switches.
 // Write lock held by InitTheme; read lock held by GetToolStyle (map access).
 var themeMu sync.RWMutex
 
+// ResolveThemeName normalizes a theme string to a canonical Theme value.
+// Handles backward-compat aliases ("dark" → "oasis-lagoon-dark", "light" → "oasis-lagoon-light").
+// Returns ThemeTerminal for unrecognized values.
+func ResolveThemeName(name string) Theme {
+	// Check aliases first (backward compat)
+	if t, ok := themeAliases[name]; ok {
+		return t
+	}
+	// Check canonical names
+	t := Theme(name)
+	if _, ok := palettes[t]; ok {
+		return t
+	}
+	return ThemeTerminal
+}
+
 // InitTheme sets the active color palette based on theme name
 // Must be called before any UI rendering
 func InitTheme(theme string) {
 	themeMu.Lock()
 	defer themeMu.Unlock()
-	if theme == "light" {
-		currentTheme = ThemeLight
-		ColorBg = lightColors.Bg
-		ColorSurface = lightColors.Surface
-		ColorBorder = lightColors.Border
-		ColorText = lightColors.Text
-		ColorTextDim = lightColors.TextDim
-		ColorAccent = lightColors.Accent
-		ColorPurple = lightColors.Purple
-		ColorCyan = lightColors.Cyan
-		ColorGreen = lightColors.Green
-		ColorYellow = lightColors.Yellow
-		ColorOrange = lightColors.Orange
-		ColorRed = lightColors.Red
-		ColorComment = lightColors.Comment
-	} else {
-		currentTheme = ThemeDark
-		ColorBg = darkColors.Bg
-		ColorSurface = darkColors.Surface
-		ColorBorder = darkColors.Border
-		ColorText = darkColors.Text
-		ColorTextDim = darkColors.TextDim
-		ColorAccent = darkColors.Accent
-		ColorPurple = darkColors.Purple
-		ColorCyan = darkColors.Cyan
-		ColorGreen = darkColors.Green
-		ColorYellow = darkColors.Yellow
-		ColorOrange = darkColors.Orange
-		ColorRed = darkColors.Red
-		ColorComment = darkColors.Comment
-	}
+	currentTheme = ResolveThemeName(theme)
+	p := palettes[currentTheme]
+	ColorBg = p.Bg
+	ColorInvertFg = p.InvertFg
+	ColorSurface = p.Surface
+	ColorBorder = p.Border
+	ColorText = p.Text
+	ColorTextDim = p.TextDim
+	ColorAccent = p.Accent
+	ColorPurple = p.Purple
+	ColorCyan = p.Cyan
+	ColorGreen = p.Green
+	ColorYellow = p.Yellow
+	ColorOrange = p.Orange
+	ColorRed = p.Red
+	ColorComment = p.Comment
 	// Reinitialize styles with new colors
 	initStyles()
 }
@@ -128,8 +185,8 @@ func GetCurrentTheme() Theme {
 }
 
 func init() {
-	// Default to dark theme at package init
-	InitTheme("dark")
+	// Default to terminal-adaptive theme at package init
+	InitTheme(string(ThemeTerminal))
 }
 
 // Base Styles
@@ -319,8 +376,8 @@ var (
 	styleInfoCardHeader lipgloss.Style // Bold(true).Foreground(ColorAccent)
 
 	// Badge styles
-	styleToolBadge  lipgloss.Style // Foreground(ColorBg).Background(ColorPurple).Padding(0,1)
-	styleGroupBadge lipgloss.Style // Foreground(ColorBg).Background(ColorCyan).Padding(0,1)
+	styleToolBadge  lipgloss.Style // Foreground(ColorInvertFg).Background(ColorPurple).Padding(0,1)
+	styleGroupBadge lipgloss.Style // Foreground(ColorInvertFg).Background(ColorCyan).Padding(0,1)
 
 	// List renderer styles
 	styleListEmptyBorder lipgloss.Style // Border(RoundedBorder).BorderForeground(ColorBorder)
@@ -360,10 +417,10 @@ var MenuStyle lipgloss.Style
 // Additional Styles
 var (
 	SubtitleStyle lipgloss.Style
-	ColorError    lipgloss.Color
-	ColorSuccess  lipgloss.Color
-	ColorWarning  lipgloss.Color
-	ColorPrimary  lipgloss.Color
+	ColorError    lipgloss.TerminalColor
+	ColorSuccess  lipgloss.TerminalColor
+	ColorWarning  lipgloss.TerminalColor
+	ColorPrimary  lipgloss.TerminalColor
 )
 
 // Pre-compiled styles for RenderLogoCompact (called every render frame).
@@ -402,7 +459,7 @@ func initStyles() {
 		Padding(0, 1)
 
 	HighlightStyle = lipgloss.NewStyle().
-		Foreground(ColorBg).
+		Foreground(ColorInvertFg).
 		Background(ColorAccent).
 		Bold(true)
 
@@ -469,7 +526,7 @@ func initStyles() {
 
 	SearchMatchStyle = lipgloss.NewStyle().
 		Background(ColorYellow).
-		Foreground(ColorBg).
+		Foreground(ColorInvertFg).
 		Bold(true)
 
 	// Dialog Styles
@@ -491,7 +548,7 @@ func initStyles() {
 		MarginRight(1)
 
 	DialogButtonActiveStyle = lipgloss.NewStyle().
-		Foreground(ColorBg).
+		Foreground(ColorInvertFg).
 		Background(ColorAccent).
 		Padding(0, 2).
 		MarginRight(1).
@@ -531,19 +588,19 @@ func initStyles() {
 
 	// Tag Styles
 	TagStyle = lipgloss.NewStyle().
-		Foreground(ColorBg).
+		Foreground(ColorInvertFg).
 		Background(ColorPurple).
 		Padding(0, 1).
 		MarginRight(1)
 
 	TagActiveStyle = lipgloss.NewStyle().
-		Foreground(ColorBg).
+		Foreground(ColorInvertFg).
 		Background(ColorGreen).
 		Padding(0, 1).
 		MarginRight(1)
 
 	TagErrorStyle = lipgloss.NewStyle().
-		Foreground(ColorBg).
+		Foreground(ColorInvertFg).
 		Background(ColorRed).
 		Padding(0, 1).
 		MarginRight(1)
@@ -567,21 +624,21 @@ func initStyles() {
 		PaddingLeft(2)
 
 	SessionItemSelectedStyle = lipgloss.NewStyle().
-		Foreground(ColorBg).
+		Foreground(ColorInvertFg).
 		Background(ColorAccent).
 		Bold(true).
 		PaddingLeft(0)
 
 	// Tree connector styles
 	TreeConnectorStyle = lipgloss.NewStyle().Foreground(ColorText)
-	TreeConnectorSelStyle = lipgloss.NewStyle().Foreground(ColorBg).Background(ColorAccent)
+	TreeConnectorSelStyle = lipgloss.NewStyle().Foreground(ColorInvertFg).Background(ColorAccent)
 
 	// Session status indicator styles
 	SessionStatusRunning = lipgloss.NewStyle().Foreground(ColorGreen)
 	SessionStatusWaiting = lipgloss.NewStyle().Foreground(ColorYellow)
 	SessionStatusIdle = lipgloss.NewStyle().Foreground(ColorTextDim)
 	SessionStatusError = lipgloss.NewStyle().Foreground(ColorRed)
-	SessionStatusSelStyle = lipgloss.NewStyle().Foreground(ColorBg).Background(ColorAccent)
+	SessionStatusSelStyle = lipgloss.NewStyle().Foreground(ColorInvertFg).Background(ColorAccent)
 
 	PRBadgeOpen = lipgloss.NewStyle().Foreground(ColorGreen)
 	PRBadgeDraft = lipgloss.NewStyle().Foreground(ColorComment)
@@ -592,7 +649,7 @@ func initStyles() {
 	SessionTitleDefault = lipgloss.NewStyle().Foreground(ColorText)
 	SessionTitleActive = lipgloss.NewStyle().Foreground(ColorText).Bold(true)
 	SessionTitleError = lipgloss.NewStyle().Foreground(ColorText).Underline(true)
-	SessionTitleSelStyle = lipgloss.NewStyle().Bold(true).Foreground(ColorBg).Background(ColorAccent)
+	SessionTitleSelStyle = lipgloss.NewStyle().Bold(true).Foreground(ColorInvertFg).Background(ColorAccent)
 
 	// Selection indicator
 	SessionSelectionPrefix = lipgloss.NewStyle().Foreground(ColorAccent).Bold(true)
@@ -607,9 +664,9 @@ func initStyles() {
 	GroupStatusWaiting = lipgloss.NewStyle().Foreground(ColorYellow)
 
 	// Group selected styles
-	GroupNameSelStyle = lipgloss.NewStyle().Bold(true).Foreground(ColorBg).Background(ColorAccent)
-	GroupCountSelStyle = lipgloss.NewStyle().Foreground(ColorBg).Background(ColorAccent)
-	GroupExpandSelStyle = lipgloss.NewStyle().Foreground(ColorBg).Background(ColorAccent)
+	GroupNameSelStyle = lipgloss.NewStyle().Bold(true).Foreground(ColorInvertFg).Background(ColorAccent)
+	GroupCountSelStyle = lipgloss.NewStyle().Foreground(ColorInvertFg).Background(ColorAccent)
+	GroupExpandSelStyle = lipgloss.NewStyle().Foreground(ColorInvertFg).Background(ColorAccent)
 
 	// ToolStyleCache - reinitialize with current theme colors
 	ToolStyleCache = map[string]lipgloss.Style{
@@ -686,11 +743,11 @@ func initStyles() {
 
 	// Badge styles
 	styleToolBadge = lipgloss.NewStyle().
-		Foreground(ColorBg).
+		Foreground(ColorInvertFg).
 		Background(ColorPurple).
 		Padding(0, 1)
 	styleGroupBadge = lipgloss.NewStyle().
-		Foreground(ColorBg).
+		Foreground(ColorInvertFg).
 		Background(ColorCyan).
 		Padding(0, 1)
 
@@ -724,19 +781,19 @@ func initStyles() {
 	// PR detail overlay styles (must be here — pr_detail.go vars are package-level
 	// and would capture empty Color* values before InitTheme runs).
 	prDetailHeaderStyle      = lipgloss.NewStyle().Foreground(ColorAccent).Bold(true)
-	prDetailActiveTabStyle   = lipgloss.NewStyle().Foreground(ColorBg).Background(ColorAccent).Bold(true).Padding(0, 1)
+	prDetailActiveTabStyle   = lipgloss.NewStyle().Foreground(ColorInvertFg).Background(ColorAccent).Bold(true).Padding(0, 1)
 	prDetailInactiveTabStyle = lipgloss.NewStyle().Foreground(ColorComment).Padding(0, 1)
 
 	// Nav tab styles (Sessions | PRs | Todos tab row)
-	navTabActiveStyle   = lipgloss.NewStyle().Foreground(ColorBg).Background(ColorAccent).Bold(true).Padding(0, 1)
+	navTabActiveStyle   = lipgloss.NewStyle().Foreground(ColorInvertFg).Background(ColorAccent).Bold(true).Padding(0, 1)
 	navTabInactiveStyle = lipgloss.NewStyle().Foreground(ColorComment).Background(ColorSurface).Padding(0, 1)
 
 	// Filter pill styles (Running / Waiting / Idle / Error pills)
-	filterPillAllActiveStyle     = lipgloss.NewStyle().Foreground(ColorBg).Background(ColorAccent).Bold(true).Padding(0, 1)
-	filterPillRunningActiveStyle = lipgloss.NewStyle().Foreground(ColorBg).Background(ColorGreen).Bold(true).Padding(0, 1)
-	filterPillWaitingActiveStyle = lipgloss.NewStyle().Foreground(ColorBg).Background(ColorYellow).Bold(true).Padding(0, 1)
-	filterPillIdleActiveStyle    = lipgloss.NewStyle().Foreground(ColorBg).Background(ColorTextDim).Bold(true).Padding(0, 1)
-	filterPillErrorActiveStyle   = lipgloss.NewStyle().Foreground(ColorBg).Background(ColorRed).Bold(true).Padding(0, 1)
+	filterPillAllActiveStyle     = lipgloss.NewStyle().Foreground(ColorInvertFg).Background(ColorAccent).Bold(true).Padding(0, 1)
+	filterPillRunningActiveStyle = lipgloss.NewStyle().Foreground(ColorInvertFg).Background(ColorGreen).Bold(true).Padding(0, 1)
+	filterPillWaitingActiveStyle = lipgloss.NewStyle().Foreground(ColorInvertFg).Background(ColorYellow).Bold(true).Padding(0, 1)
+	filterPillIdleActiveStyle    = lipgloss.NewStyle().Foreground(ColorInvertFg).Background(ColorTextDim).Bold(true).Padding(0, 1)
+	filterPillErrorActiveStyle   = lipgloss.NewStyle().Foreground(ColorInvertFg).Background(ColorRed).Bold(true).Padding(0, 1)
 	filterPillInactiveStyle      = lipgloss.NewStyle().Foreground(ColorComment).Padding(0, 1)
 	filterPillDimStyle           = lipgloss.NewStyle().Foreground(ColorText).Faint(true).Padding(0, 1)
 
@@ -827,7 +884,7 @@ func ToolIcon(tool string) string {
 
 // ToolColor returns the brand color for a given tool
 // Claude=orange (Anthropic), Gemini=purple (Google AI), Codex=cyan, Aider=red
-func ToolColor(tool string) lipgloss.Color {
+func ToolColor(tool string) lipgloss.TerminalColor {
 	switch tool {
 	case "claude":
 		return ColorOrange // Anthropic's orange
@@ -857,7 +914,7 @@ func GetToolStyle(tool string) lipgloss.Style {
 
 // RenderLogoIndicator renders a single indicator with appropriate color
 func RenderLogoIndicator(indicator string) string {
-	var color lipgloss.Color
+	var color lipgloss.TerminalColor
 	switch indicator {
 	case "●":
 		color = ColorGreen // Running
@@ -901,13 +958,13 @@ func getLogoIndicators(running, waiting, idle int) []string {
 // bg must match the row's background color so that each segment
 // explicitly declares it — preventing lipgloss \x1b[0m resets from
 // exposing the terminal default background between segments.
-func RenderLogoCompact(running, waiting, idle int, bg lipgloss.Color) string {
+func RenderLogoCompact(running, waiting, idle int, bg lipgloss.TerminalColor) string {
 	indicators := getLogoIndicators(running, waiting, idle)
 	bracketStyle := logoCompactBracketBase.Background(bg)
 	borderStyle := logoCompactBorderBase.Background(bg)
 	sp := logoCompactSpaceBase.Background(bg).Render(" ")
 	indicator := func(ind string) string {
-		var color lipgloss.Color
+		var color lipgloss.TerminalColor
 		switch ind {
 		case "●":
 			color = ColorGreen

--- a/internal/ui/styles_test.go
+++ b/internal/ui/styles_test.go
@@ -4,19 +4,21 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 func TestColorsDefined(t *testing.T) {
-	colors := []string{
-		string(ColorBg),
-		string(ColorSurface),
-		string(ColorBorder),
-		string(ColorText),
-		string(ColorAccent),
+	colors := []lipgloss.TerminalColor{
+		ColorBg,
+		ColorSurface,
+		ColorBorder,
+		ColorText,
+		ColorAccent,
 	}
 	for _, c := range colors {
-		if c == "" {
-			t.Error("Color should not be empty")
+		if c == nil {
+			t.Error("Color should not be nil")
 		}
 	}
 }
@@ -72,8 +74,8 @@ func TestInitTheme_Dark(t *testing.T) {
 	if GetCurrentTheme() != ThemeDark {
 		t.Errorf("Expected ThemeDark, got %v", GetCurrentTheme())
 	}
-	if ColorBg != darkColors.Bg {
-		t.Errorf("ColorBg should be dark theme color")
+	if ColorBg != palettes[ThemeOasisLagoonDark].Bg {
+		t.Errorf("ColorBg should be oasis-lagoon-dark theme color")
 	}
 }
 
@@ -82,33 +84,54 @@ func TestInitTheme_Light(t *testing.T) {
 	if GetCurrentTheme() != ThemeLight {
 		t.Errorf("Expected ThemeLight, got %v", GetCurrentTheme())
 	}
-	if ColorBg != lightColors.Bg {
-		t.Errorf("ColorBg should be light theme color")
+	if ColorBg != palettes[ThemeOasisLagoonLight].Bg {
+		t.Errorf("ColorBg should be oasis-lagoon-light theme color")
 	}
 	// Reset to dark for other tests
 	InitTheme("dark")
 }
 
-func TestInitTheme_InvalidFallsToDark(t *testing.T) {
+func TestInitTheme_CanonicalNames(t *testing.T) {
+	InitTheme("oasis-lagoon-dark")
+	if GetCurrentTheme() != ThemeOasisLagoonDark {
+		t.Errorf("Expected ThemeOasisLagoonDark, got %v", GetCurrentTheme())
+	}
+
+	InitTheme("oasis-lagoon-light")
+	if GetCurrentTheme() != ThemeOasisLagoonLight {
+		t.Errorf("Expected ThemeOasisLagoonLight, got %v", GetCurrentTheme())
+	}
+
+	InitTheme("terminal")
+	if GetCurrentTheme() != ThemeTerminal {
+		t.Errorf("Expected ThemeTerminal, got %v", GetCurrentTheme())
+	}
+	// Terminal theme uses ANSIColor — verify colors are set (non-nil)
+	if ColorBg == nil || ColorText == nil || ColorAccent == nil {
+		t.Error("Terminal theme colors should be non-nil")
+	}
+
+	// Reset for other tests
+	InitTheme("dark")
+}
+
+func TestInitTheme_InvalidFallsToTerminal(t *testing.T) {
 	InitTheme("invalid")
-	if GetCurrentTheme() != ThemeDark {
-		t.Errorf("Invalid theme should fall back to dark")
+	if GetCurrentTheme() != ThemeTerminal {
+		t.Errorf("Invalid theme should fall back to terminal")
 	}
 }
 
 func TestInitTheme_StylesReinitialized(t *testing.T) {
 	// Initialize with light theme
 	InitTheme("light")
-	// Check that a style uses light theme colors
-	// BaseStyle should have ColorText foreground, which for light theme is #343b58
-	if ColorText != lightColors.Text {
+	if ColorText != palettes[ThemeOasisLagoonLight].Text {
 		t.Errorf("ColorText should be light theme value after InitTheme(light)")
 	}
 
 	// Switch to dark theme
 	InitTheme("dark")
-	// Check that colors switched
-	if ColorText != darkColors.Text {
+	if ColorText != palettes[ThemeOasisLagoonDark].Text {
 		t.Errorf("ColorText should be dark theme value after InitTheme(dark)")
 	}
 }


### PR DESCRIPTION
## What

Hangar now supports a "terminal" theme that uses ANSI palette colors (0-15) instead of hardcoded hex values. When enabled, both the TUI and tmux status bar automatically follow the terminal's color scheme — change your terminal to Tokyo Night, Catppuccin, Gruvbox, or any theme and Hangar adapts instantly. This is now the default theme.

## Why

The previous hardcoded hex color palette (oasis-lagoon-dark) looked good in isolation but clashed with users' terminal themes. By mapping to ANSI color slots 0-15, Hangar inherits whatever palette the terminal provides — zero configuration, instant theme switching.

## What Changed

- **Theme system** — `colorPalette` fields changed from `lipgloss.Color` to `lipgloss.TerminalColor` interface, enabling ANSI palette slots and `NoColor{}` (transparent backgrounds)
- **Terminal theme** — new palette using ANSI colors 0-15 with `NoColor{}` for backgrounds
- **`ColorInvertFg`** — separated from `ColorBg` for inverted/highlighted elements (dark text on colored pills/badges)
- **Theme-aware tmux status bar** — `ConfigureStatusBar()` and notification pill use ANSI color names in terminal mode
- **Named themes** — renamed "dark"/"light" to "oasis-lagoon-dark"/"oasis-lagoon-light" with backward-compat aliases
- **Default changed to "terminal"** — existing configs with "dark"/"light" are aliased and unaffected
- **Settings panel** — expanded to show Oasis Dark, Oasis Light, Terminal, System options

### Files changed (20 files, +545 −295)

| Area | Files |
|------|-------|
| Theme core | `styles.go`, `styles_test.go` |
| Settings | `settings_panel.go`, `settings_panel_test.go` |
| Config | `userconfig.go`, `userconfig_test.go` |
| tmux status bar | `tmux.go` |
| Notifications | `notifications.go`, `notifications_test.go` |
| UI dialogs/views | `home.go`, `confirm_dialog.go`, `global_search.go`, `group_dialog.go`, `newdialog.go`, `preview_renderer.go`, `search.go`, `setup_wizard.go`, `setup_wizard_test.go` |
| Session model | `instance.go` |
| Changelog | `CHANGELOG.md` |

## Testing

- [x] All tests passing (`go test ./internal/ui/ ./internal/session/ ./internal/tmux/`)
- [x] Manual testing with Tokyo Night terminal theme
- [x] Verified backward-compat aliases ("dark" → "oasis-lagoon-dark", "light" → "oasis-lagoon-light")

## Screenshots / demo

Terminal theme automatically adapts to whatever color scheme is active — no Hangar config change needed. Switch terminal theme and Hangar follows.